### PR TITLE
Let customer agent decide when to fetch messages

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/customer/agent.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/customer/agent.py
@@ -209,7 +209,7 @@ class CustomerAgent(BaseSimpleMarketplaceAgent[CustomerAgentProfile]):
                 search_response = SearchResponse.model_validate(search_result.content)
                 business_ids = [ba.id for ba in search_response.businesses]
                 self.known_business_ids.extend(business_ids)
-        # Search for new messages
+        # Check for new messages
         elif action.action_type == "check_messages":
             fetch_response = await self.fetch_messages()
             messages = fetch_response.messages


### PR DESCRIPTION
Remove programatic fetch-messages call, leave it up to the CustomerAgent's 'check_messages' action do that. This is a closer reproduction of v1.

Resolves: https://github.com/microsoft/multi-agent-marketplace/issues/34

To test:

```
uv run magentic-marketplace run data/mexican_3_9
```

---

**PR Checklist (do not remove):**
- [x] I've added necessary new tests and they pass
- [x] My PR description explains how to test this contribution
- [x] I have linked this PR to an issue
- [x] I have requested reviews from two people
