### PR TITLE
Wait for healthcheck to pass before returning

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/platform/launcher.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/platform/launcher.py
@@ -114,7 +114,8 @@ class MarketplaceLauncher:
                         f"MarketplaceServer is running and healthy at {self.server_url}"
                     )
                     return
-            except Exception:
+            except Exception as e:
+                last_exception = e
                 await asyncio.sleep(current_delay)
                 current_delay = min(current_delay * 2, max_delay)  # Exponential backoff
 


### PR DESCRIPTION
Adam discovered a race condition on Windows where the agents and loggers attempted to connect to the FastAPI server before it was healthy. This PR adds a health-check-and-retry loop until the server becomes healthy or max retries (10) are exceeded.

To test:

```
uv run magentic-marketplace run data/mexican_3_9
```


---

**PR Checklist (do not remove):**
- [x] I've added necessary new tests and they pass
- [x] My PR description explains how to test this contribution
- [ ] I have linked this PR to an issue
- [x] I have requested reviews from two people
