### PR TITLE
Remove redundant info from customer prompt

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/customer/prompts.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/customer/prompts.py
@@ -58,10 +58,6 @@ Current Time: {current_time}
 You are an autonomous agent working for customer {self.customer.name}.
 They have the following request: {self.customer.request}
 
-Customer preferences:
-- Interested menu items: {", ".join(f"{item} (${price})" for item, price in self.customer.menu_features.items())}
-- Required amenities: {", ".join(self.customer.amenity_features)}
-
 IMPORTANT: You must fulfill their request using only the available actions.
 
 Available Actions:


### PR DESCRIPTION
This removes some reundant info from the customer prompt. HOWEVER, I've noticed this can result in some weird regressions in behavior with gpt-4o.

Before it could easily run on mexican_3_9, however with this change I noticed that one customer gets stuck trying to end the transaction for an order proposal they never received. 

The weird thing is the prompt change has nothing to do with this???

# Test
Run this experiment like 3 times...
```bash
LLM_MODEL="gpt-4o" magentic-marketplace run data/mexican_3_9
```

I regularly get this in my output:
```bash
WARNING [customer_0002] (18:55:40) Error: proposal_to_accept 'business_0006-0' does not match any known proposals.
INFO [customer_0002] (18:55:44) Next action: end_transaction. Reason: Margarita Mesa offers the requested drink and allows walk-ins, which aligns with the customer's requirements.
WARNING [customer_0002] (18:55:44) Error: proposal_to_accept 'business_0006-0' does not match any known proposals.
INFO [customer_0002] (18:55:48) Next action: end_transaction. Reason: Margarita Mesa offers the requested drink and allows walk-ins, fulfilling the customer's request.
WARNING [customer_0002] (18:55:48) Error: proposal_to_accept 'business_0006-0' does not match any known proposals.
INFO [customer_0002] (18:55:51) Next action: end_transaction. Reason: Margarita Mesa offers the requested drink and allows walk-ins, which aligns with the customer's requirements.
WARNING [customer_0002] (18:55:51) Error: proposal_to_accept 'business_0006-0' does not match any known proposals.
```

This doesnt happen every time for me, but quite consistently (e.g 4/5 runs).

# Other experiments
Weirdly, when I run on larger datasets with gpt-4o (e.g. mexican_100_300) it does fine.

I also have not noticed this issue with newer better models.

# TLDR
Not sure if we actually want to make this change, putting in this PR to discuss and see if other people are noticing same issue.

---

**PR Checklist (do not remove):**
- [x] I've added necessary new tests and they pass
- [x] My PR description explains how to test this contribution
- [ ] I have linked this PR to an issue
- [x] I have requested reviews from two people
