### PR TITLE
Fix python 3.11 syntax error

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/customer/prompts.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/customer/prompts.py
@@ -270,13 +270,12 @@ Choose your action carefully.
         for pay_message, pay_message_result in zip(
             pay_messages, message_results.pay_message_results, strict=True
         ):
+            pay_message_str = pay_message.model_dump_json(
+                exclude={"type", "to_business_id"},
+                exclude_none=True,
+            )
             send_message_result_lines.append(
-                f"Sent to {pay_message.to_business_id}: {
-                    pay_message.model_dump_json(
-                        exclude={'type', 'to_business_id'},
-                        exclude_none=True,
-                    )
-                }"
+                f"Sent to {pay_message.to_business_id}: {pay_message_str}"
             )
             is_success, error_message = pay_message_result
             if is_success:


### PR DESCRIPTION
Fixes python 3.13 syntax that was incompatible with 3.11

To test, run the usual magentic-marketplace run script.


---

**PR Checklist (do not remove):**
- [] I've added necessary new tests and they pass
- [] My PR description explains how to test this contribution
- [ ] I have linked this PR to an issue
- [ ] I have requested reviews from two people
