### PR TITLE
Report missing proposals and attribute utility gaps

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/experiments/models/analytics.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/experiments/models/analytics.py
@@ -10,9 +10,14 @@ class CustomerSummary(BaseModel):
     customer_name: str
     messages_sent: int
     proposals_received: int
+    proposals_in_last_llm_call: list[str]
+    """The OrderProposal ids that were in the final LLM call made by this customer.
+    i.e. how many of the received proposals did the customer actually see."""
     payments_made: int
     searches_made: int
     utility: float
+    optimal_utility: float
+    utility_gap: float
     needs_met: bool
 
 
@@ -33,6 +38,31 @@ class TransactionSummary(BaseModel):
     payments_made: int
     average_proposal_value: float | None = None
     average_paid_order_value: float | None = None
+
+
+class SuboptimalCustomersSummary(BaseModel):
+    """Summary of customers that achieved suboptimal utility.
+
+    Breaks down the suboptimal utility gaps into categories {needs_met, needs_not_met} x {saw_all_proposals, missing_some_proposals}
+
+    Useful for identifying whether the LLM just did a bad job of picking the right proposal, or acted too fast and never saw the right proposal.
+
+    needs_met_utility_gap = needs_met_all_proposals_utility_gap + needs_met_missing_proposals_utility_gap
+    needs_not_met_utility_gap = needs_not_met_all_proposals_utility_gap + needs_not_met_missing_proposals_utility_gap
+    total_utility_gap = needs_not_met_utility_gap + needs_met_utility_gap
+
+    """
+
+    total_suboptimal_customers: int
+    needs_met: list[CustomerSummary]
+    needs_met_utility_gap: float
+    needs_met_all_proposals_utility_gap: float
+    needs_met_missing_proposals_utility_gap: float
+    needs_not_met: list[CustomerSummary]
+    needs_not_met_utility_gap: float
+    needs_not_met_all_proposals_utility_gap: float
+    needs_not_met_missing_proposals_utility_gap: float
+    total_utility_gap: float
 
 
 class AnalyticsResults(BaseModel):
@@ -61,9 +91,16 @@ class AnalyticsResults(BaseModel):
     total_llm_calls: int
     failed_llm_calls: int
 
+    # Behavior summary
+    businesses_who_sent_proposals: int
+    customers_who_did_not_see_all_proposals: int
+    """The number of customers who did not include all received proposals in their final LLM call."""
+    suboptimal_customers_summary: SuboptimalCustomersSummary
+
     # Final summary metrics
     customers_who_made_purchases: int
     customers_with_needs_met: int
     total_marketplace_customer_utility: float
+    optimal_marketplace_customer_utility: float
     average_utility_per_active_customer: float | None = None
     purchase_completion_rate: float


### PR DESCRIPTION
To help debug why utility is low, attribute lost utility to 4 groups of suboptimal customers: 
1. customers with their needs met who saw all proposals but were suboptimal
2. customers with their needs met who did not see all proposals and were suboptimal
3. customers without their needs met who did see all proposals but were suboptimal
4. customers without their needs met who did not see all proposals and were suboptimal.

To test

```
magentic-marketplace analyze <experiment name>
```

You should see a new summary section:
```
PROPOSALS AND UTILITY LOST SUMMARY:
========================================
Businesses who sent proposals: 259/300
Customers who didn't see all proposals: 13/100
Utility lost due to customers with
  needs met and
    saw all proposals: 21.27
    missing some proposals: 15.11
  needs not met and
    saw all proposals: 112.35
    missing some proposals: 0.00
```

---

**PR Checklist (do not remove):**
- [ ] I've added necessary new tests and they pass
- [x] My PR description explains how to test this contribution
- [ ] I have linked this PR to an issue
- [x] I have requested reviews from two people
