### PR TITLE
Validate generated order proposals before send

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/business/responses.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/marketplace/agents/business/responses.py
@@ -67,14 +67,7 @@ class ResponseHandler:
             conversation_history, customer_id, context=context
         )
 
-        try:
-            action, _ = await self.generate_struct_fn(prompt, BusinessAction)
-        except Exception:
-            self.logger.exception("LLM response generation failed.")
-            # Fallback to simple text response
-            return TextMessage(
-                content="I'm sorry, I'm having trouble processing your request right now. Please try again."
-            )
+        action, _ = await self.generate_struct_fn(prompt, BusinessAction)
 
         try:
             # Type assertion for proper type checking


### PR DESCRIPTION
Business agents generated OrderProposal messages via an LLM call, but we were not doing any validation that the generated proposal A) contained items that are actually on the businesses menu or B) that the total price offered actually was equal to the sum of the unit prices.

This change introduces that validation and allows the LLM to retry up to 3 times, showing it the validation errors each time.

To test,

In your .env:

```
LLM_PROVIDER="openai"
LLM_MODEL="gpt-5-nano"
```

Then

```
magentic-marketplace run data/mexican_100_300 --experiment-name validate_proposals
```

Wait for a while (or for the run to complete) then run

```bash
docker exec -i multi-agent-marketplace-postgres-1 psql -U postgres -d marketplace -c "SELECT data->'data'->>'prompt' FROM validate_proposals.logs WHERE data->'data'->>'prompt' ILIKE '%You just generated the following BusinessAction%' ORDER BY row_index DESC LIMIT 1" > prompt.txt
```

Open prompt.txt, you should see a line in there. You can format it (e.g. replacing \n with actual newlines) and confirm that the prompt contains a section like this:

```
Context: You just generated the following BusinessAction:
\`\`\`json
{\"action_type\":\"order_proposal\",\"text_message\":null,\"order_proposal_message\":{\"type\":\"order_proposal\",\"id\":\"proposal-001\",\"items\":[{\"id\":\"Item-14\",\"item_name\":\"Jalapeño Watermelon Sangria\",\"quantity\":1,\"unit_price\":8.61},{\"id\":\"Item-8\",\"item_name\":\"Pepper Jack Cornbread Muffins\",\"quantity\":1,\"unit_price\":3.17},{\"id\":\"Item-12\",\"item_name\":\"Pepper Jack Quesadilla\",\"quantity\":1,\"unit_price\":7.82}],\"total_price\":19.6,\"special_instructions\":\"Reservation policy: Takes reservations. Outdoor seating is available. Please note we do not offer delivery.\",\"estimated_delivery\":\"In-restaurant dining or pickup\",\"expiry_time\":null,\"to_customer_id\":\"customer_0061-0\"}}
\`\`\`
And encountered the following error(s):
\`\`\`
Encountered 1 errors validating order_proposal_message:
- 'Jalapeño Watermelon Sangria' does not match any menu items.
\`\`\`
```


---

**PR Checklist (do not remove):**
- [ ] I've added necessary new tests and they pass
- [x] My PR description explains how to test this contribution
- [ ] I have linked this PR to an issue
- [x] I have requested reviews from two people
