### PR TITLE
Move 'Run analytics...' prompt to experiment command

### DIFF
--- a/packages/magentic-marketplace/src/magentic_marketplace/experiments/run_experiment.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/experiments/run_experiment.py
@@ -137,3 +137,5 @@ async def run_marketplace_experiment(
                 db = marketplace_launcher.server.state.database_controller
                 await convert_postgres_to_sqlite(db, sqlite_path)
                 logger.info(f"Database conversion complete: {sqlite_path}")
+
+        print(f"\nRun analytics with: magentic-marketplace analyze {experiment_name}")

--- a/packages/magentic-marketplace/src/magentic_marketplace/platform/launcher.py
+++ b/packages/magentic-marketplace/src/magentic_marketplace/platform/launcher.py
@@ -137,10 +137,6 @@ class MarketplaceLauncher:
                 pass
 
         print("Server stopped")
-        if self.experiment_name:
-            print(
-                f"\nRun analytics with: magentic-marketplace analyze {self.experiment_name}"
-            )
 
     async def create_logger(self, name: str = __name__) -> MarketplaceLogger:
         """Create a logger connected to the marketplace.


### PR DESCRIPTION
Previously we printed

```
Run analytics with: magentic-marketplace analyze {experiment_name}
```

when the platform launcher shutdown. But the launcher is protocol-agnostic, so for non-marketplace protocols this print didn't make sense.

Moved the print to the end of the `magentic-marketplace run` command's entrypoint. 

---

**PR Checklist (do not remove):**
- [ ] I've added necessary new tests and they pass
- [ ] My PR description explains how to test this contribution
- [ ] I have linked this PR to an issue
- [x] I have requested reviews from two people
